### PR TITLE
fix(MessageID/TemplateID): Replace usize with u64 for 32-bit machine support

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.3.1] - 2025-07-27
+### Improved
+ - Deserialization for `usize` changed to `u64` for 32-bit machine support.
+
 ## [v0.2.0] - 2021-08-01
 ### Added
 - Support tokio 1.x instead of 0.x

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mailjet-rs"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Esteban Borai <estebanborai@gmail.com>"]
 edition = "2021"
 license = "MIT"

--- a/lib/src/api/v3/message.rs
+++ b/lib/src/api/v3/message.rs
@@ -335,7 +335,7 @@ pub struct Message {
     /// the ID returned by the /template resource.
     #[serde(rename = "Mj-TemplateID")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub mj_template_id: Option<usize>,
+    pub mj_template_id: Option<u64>,
     /// Flag for Mailjet's `Message` to interpret the template language
     #[serde(rename = "Mj-TemplateLanguage")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -476,7 +476,7 @@ impl Message {
     ///
     /// This method is used when using a template language for your
     /// `Message`
-    pub fn set_template_id(&mut self, id: usize) {
+    pub fn set_template_id(&mut self, id: u64) {
         self.mj_template_id = Some(id);
         self.use_mj_template_language = Some(true);
     }

--- a/lib/src/client/response.rs
+++ b/lib/src/client/response.rs
@@ -10,7 +10,7 @@ pub struct Sent {
     #[serde(rename = "Email")]
     pub email: String,
     #[serde(rename = "MessageID")]
-    pub message_id: usize,
+    pub message_id: u64,
     #[serde(rename = "MessageUUID")]
     pub message_uuid: String,
 }


### PR DESCRIPTION
Fixes #62

Replaces instances of `usize` with `u64` to support 32 bit machines, Mailjet doesn't seem to specify how large the `MessageID` field will be: https://dev.mailjet.com/email/guides/send-api-V3/#send-a-basic-email
